### PR TITLE
Update python_version for 3.13

### DIFF
--- a/darktrace.json
+++ b/darktrace.json
@@ -52,7 +52,7 @@
     "product_vendor": "Darktrace",
     "product_version_regex": ".*",
     "publisher": "Darktrace",
-    "python_version": "3",
+    "python_version": ["3.9", "3.13"],
     "fips_compliant": false,
     "type": "siem",
     "utctime_updated": "2025-04-14T15:51:36.096676Z",

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Update Python version for 3.13


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13

[_Created by Sourcegraph batch change `grokas-splunk/002-update-python-versions`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/002-update-python-versions)