### PR TITLE
PSAAS-28910 darktrace VULN update

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,13 @@ default_stages: [pre-commit]
 # This is a template for connector pre-commit hooks
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.1.0
+    rev: v4.3.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: [--verbose]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
@@ -27,7 +27,7 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.7
+    rev: v0.14.6
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
@@ -42,11 +42,6 @@ repos:
     hooks:
       - id: soar-app-linter
         args: ["--single-repo", "--message-level", "error"]
-  - repo: https://github.com/hukkin/mdformat
-    rev: 0.7.22
-    hooks:
-      - id: mdformat
-        exclude: "release_notes/.*"
   - repo: https://github.com/returntocorp/semgrep
     rev: v1.136.0
     hooks:

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) Darktrace, 2021-2025
+   Copyright (c) Darktrace, 2021-2026
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Splunk SOAR App: Darktrace
-Copyright (c) Darktrace, 2021-2025
+Copyright (c) Darktrace, 2021-2026
 Third Party Software Attributions:
 
 @@@@============================================================================
@@ -110,3 +110,4 @@ e) to display the Original Work publicly.
 15) Right to Use. You may use the Original Work in all ways not otherwise restricted or conditioned by this License or by law, and Licensor promises not to interfere with or be responsible for such uses by You.
 
 This license is Copyright (C) 2003-2004 Lawrence E. Rosen. All rights reserved. Permission is hereby granted to copy and distribute this license without modification. This license may not be modified without the express written permission of its copyright owner.
+

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Darktrace
 
-Publisher: Darktrace \
-Connector Version: 1.0.8 \
-Product Vendor: Darktrace \
-Product Name: Darktrace \
+Publisher: Darktrace <br>
+Connector Version: 1.0.8 <br>
+Product Vendor: Darktrace <br>
+Product Name: Darktrace <br>
 Minimum Product Version: 5.3.0
 
 This app integrates with Darktrace to perform investigative and containment actions
@@ -31,24 +31,24 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 
 ### Supported Actions
 
-[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using the supplied configuration \
-[get device tags](#action-get-device-tags) - Receive all of the tags that are currently applied to a device \
-[get tagged devices](#action-get-tagged-devices) - Receive all of the devices that currently have a given tag \
-[get breach comments](#action-get-breach-comments) - Receive all comments made on a model breach \
-[on poll](#action-on-poll) - Ingests Darktrace model breaches and Cyber AI Analyst investigations \
-[get device description](#action-get-device-description) - Receive device description for the specified device \
-[get device modelbreaches](#action-get-device-modelbreaches) - Receive recent model breaches for the specified device \
-[acknowledge breach](#action-acknowledge-breach) - Acknowledge a model breach \
-[unacknowledge breach](#action-unacknowledge-breach) - Unacknowledge a model breach \
-[post comment](#action-post-comment) - Post a comment to a model breach \
-[post tag](#action-post-tag) - Post a tag to a device \
+[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using the supplied configuration <br>
+[get device tags](#action-get-device-tags) - Receive all of the tags that are currently applied to a device <br>
+[get tagged devices](#action-get-tagged-devices) - Receive all of the devices that currently have a given tag <br>
+[get breach comments](#action-get-breach-comments) - Receive all comments made on a model breach <br>
+[on poll](#action-on-poll) - Ingests Darktrace model breaches and Cyber AI Analyst investigations <br>
+[get device description](#action-get-device-description) - Receive device description for the specified device <br>
+[get device modelbreaches](#action-get-device-modelbreaches) - Receive recent model breaches for the specified device <br>
+[acknowledge breach](#action-acknowledge-breach) - Acknowledge a model breach <br>
+[unacknowledge breach](#action-unacknowledge-breach) - Unacknowledge a model breach <br>
+[post comment](#action-post-comment) - Post a comment to a model breach <br>
+[post tag](#action-post-tag) - Post a tag to a device <br>
 [get breach connections](#action-get-breach-connections) - Receive connections involved in a model breach
 
 ## action: 'test connectivity'
 
 Validate the asset configuration for connectivity using the supplied configuration
 
-Type: **test** \
+Type: **test** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -63,7 +63,7 @@ No Output
 
 Receive all of the tags that are currently applied to a device
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -88,7 +88,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Receive all of the devices that currently have a given tag
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -118,7 +118,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Receive all comments made on a model breach
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -145,7 +145,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Ingests Darktrace model breaches and Cyber AI Analyst investigations
 
-Type: **ingest** \
+Type: **ingest** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -177,7 +177,7 @@ action_result.parameter.artifact_count | numeric | | |
 
 Receive device description for the specified device
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -210,7 +210,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Receive recent model breaches for the specified device
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -240,7 +240,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Acknowledge a model breach
 
-Type: **correct** \
+Type: **correct** <br>
 Read only: **False**
 
 #### Action Parameters
@@ -265,7 +265,7 @@ summary.total_objects_successful | numeric | | |
 
 Unacknowledge a model breach
 
-Type: **correct** \
+Type: **correct** <br>
 Read only: **False**
 
 #### Action Parameters
@@ -290,7 +290,7 @@ summary.total_objects_successful | numeric | | |
 
 Post a comment to a model breach
 
-Type: **correct** \
+Type: **correct** <br>
 Read only: **False**
 
 #### Action Parameters
@@ -317,7 +317,7 @@ summary.total_objects_successful | numeric | | |
 
 Post a tag to a device
 
-Type: **correct** \
+Type: **correct** <br>
 Read only: **False**
 
 #### Action Parameters
@@ -346,7 +346,7 @@ summary.total_objects_successful | numeric | | |
 
 Receive connections involved in a model breach
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -378,7 +378,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Splunk Inc.
+# Copyright (c) 2025-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/darktrace.json
+++ b/darktrace.json
@@ -41,7 +41,7 @@
         }
     },
     "description": "This app integrates with Darktrace to perform investigative and containment actions",
-    "license": "Copyright (c) Darktrace, 2021-2025",
+    "license": "Copyright (c) Darktrace, 2021-2026",
     "logo": "logo_darktrace.svg",
     "logo_dark": "logo_darktrace_dark.svg",
     "main_module": "darktrace_connector.py",

--- a/darktrace/__init__.py
+++ b/darktrace/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Splunk Inc.
+# Copyright (c) 2025-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/darktrace/client/__init__.py
+++ b/darktrace/client/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Splunk Inc.
+# Copyright (c) 2025-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/darktrace/client/darktrace_ai_analyst_objects.py
+++ b/darktrace/client/darktrace_ai_analyst_objects.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Splunk Inc.
+# Copyright (c) 2025-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/darktrace/client/darktrace_client.py
+++ b/darktrace/client/darktrace_client.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Splunk Inc.
+# Copyright (c) 2025-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -71,7 +71,6 @@ class DarktraceClient:
     def from_connector(cls, connector: "DarktraceConnector") -> "DarktraceClient":
         """Create a client from the DarktraceConnector object"""
         config = connector.get_config()
-        connector.debug_print(config)
         return cls(
             config["base_url"],
             config["public_token"],

--- a/darktrace/client/darktrace_model_breach_objects.py
+++ b/darktrace/client/darktrace_model_breach_objects.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Splunk Inc.
+# Copyright (c) 2025-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/darktrace/client/darktrace_resp_processer.py
+++ b/darktrace/client/darktrace_resp_processer.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Splunk Inc.
+# Copyright (c) 2025-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/darktrace/darktrace_consts.py
+++ b/darktrace/darktrace_consts.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Splunk Inc.
+# Copyright (c) 2025-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/darktrace/darktrace_utils.py
+++ b/darktrace/darktrace_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Splunk Inc.
+# Copyright (c) 2025-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/darktrace/handlers/__init__.py
+++ b/darktrace/handlers/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Splunk Inc.
+# Copyright (c) 2025-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/darktrace/handlers/darktrace_connectivity_handler.py
+++ b/darktrace/handlers/darktrace_connectivity_handler.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Splunk Inc.
+# Copyright (c) 2025-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/darktrace/handlers/darktrace_device_handler.py
+++ b/darktrace/handlers/darktrace_device_handler.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Splunk Inc.
+# Copyright (c) 2025-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/darktrace/handlers/darktrace_handler.py
+++ b/darktrace/handlers/darktrace_handler.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Splunk Inc.
+# Copyright (c) 2025-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/darktrace/handlers/darktrace_model_breach_handler.py
+++ b/darktrace/handlers/darktrace_model_breach_handler.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Splunk Inc.
+# Copyright (c) 2025-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/darktrace/handlers/darktrace_poll_handler.py
+++ b/darktrace/handlers/darktrace_poll_handler.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Splunk Inc.
+# Copyright (c) 2025-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/darktrace_connector.py
+++ b/darktrace_connector.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Splunk Inc.
+# Copyright (c) 2025-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* pre-commit update


### PR DESCRIPTION
## Bug fix

Removed the full asset-configuration debug print from Darktrace client creation so private and public API tokens are never written to connector debug logs.

The fix was verified in the app editor and merged on June 29, 2026.

## Tracking reconciliation

- Original finding: PSAAS-28910
- Duplicate Flashpoint finding: PSAAS-31034
- Connector story: PAPP-38155
- Parent epic: ESPM-5228

This tracking update was written by Codex with AI assistance; the original connector fix predates this reconciliation.